### PR TITLE
[WM] throw a better error msg when no config.edn found

### DIFF
--- a/src/turbovote/resource_config.clj
+++ b/src/turbovote/resource_config.clj
@@ -11,7 +11,8 @@
      (if-let [file (io/resource config-file)]
        (with-open [r (io/reader file)]
          (edn/read {:readers *data-readers*} (java.io.PushbackReader. r)))
-       (throw (Exception. (str "Config file " config-file " not found in resource paths.")))))))
+       (throw (java.io.FileNotFoundException.
+               (str "Config file " config-file " not found in resource paths.")))))))
 
 (defn config [& keys]
   (get-in (read-config config-file-name) keys))

--- a/test/turbovote/test/resource_config.clj
+++ b/test/turbovote/test/resource_config.clj
@@ -12,6 +12,6 @@
 
 (deftest missing-config-test
   (is (thrown-with-msg?
-       Exception #"Config file __missing__\.edn not found in resource paths"
+       java.io.FileNotFoundException #"Config file __missing__\.edn not found in resource paths"
        (with-redefs [turbovote.resource-config/config-file-name "__missing__.edn"]
          (config :foo)))))


### PR DESCRIPTION
I got tired of remembering that `java.lang.IllegalArgumentException: No implementation of method: :make-reader of protocol: #'clojure.java.io/IOFactory found for class: nil` usually means resource-config isn't finding a config.edn file.
