### PR TITLE
bring back zero-arity config to get everything

### DIFF
--- a/src/turbovote/resource_config.clj
+++ b/src/turbovote/resource_config.clj
@@ -27,6 +27,7 @@
 
   If a value at `keys` does not exist and a `default` is given,
   returns the default."
+  ([] (config []))
   ([keys]
    (let [config (read-config config-file-name)
          val (get-in config keys ::not-found)]


### PR DESCRIPTION
This is very handy at a REPL, and notification-works (at least) is using it to log the config on startup.