### PR TITLE
fix broken require - required for 1.9 to work, apparently

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject turbovote.resource-config "0.2.1-SNAPSHOT"
+(defproject turbovote.resource-config "0.2.1"
   :description "Simple (too simple?) configuration handling"
   :url "http://github.com/turbovote/resource-config"
   :license {:name "Eclipse Public License"

--- a/src/turbovote/resource_config/data_readers.clj
+++ b/src/turbovote/resource_config/data_readers.clj
@@ -1,5 +1,5 @@
 (ns turbovote.resource-config.data-readers
-  (require [clojure.edn :as edn]))
+  (:require [clojure.edn :as edn]))
 
 (defn env [variable]
   (System/getenv variable))


### PR DESCRIPTION
Needed so we can use spec.  Also see https://github.com/democracyworks/turbovote-admin-specs/pull/1