### PR TITLE
Allow reloading the config & finally change the name and organization of this lib

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## Changes between resource-config 0.2.1 and 1.0.0-SNAPSHOT
+
+### Added a `resource-config.core/reload-config!` fn
+
+This resets the internal config state so that subsequent calls to
+`resource-config.core/config` will pick up changes in your config file. This is
+handy for integrating with application lifecycle managers like
+[component](https://github.com/stuartsierra/component),
+[integrant](https://github.com/weavejester/integrant),
+and [mount](https://github.com/tolitius/mount).
+
+### Renamed the library to democracyworks/resource-config
+
+**This is a breaking change**
+
+Renamed the library to democracyworks/resource-config and removed
+`turbovote` from the namespaces. This is how our other libraries
+are named and organized, but we hadn't gotten around to this one yet.
+
+To use this version, change your lein dependency from:
+`[turbovote.resource-config "n.n.n"]` to:
+`[democracyworks/resource-config "1.0.0"]`.
+...and then change your requires from:
+`[turbovote.resource-config :refer [config]]` to:
+`[resource-config.core :refer [config]]`.
+
 ## Changes between resource-config 0.2.0 and 0.2.1
 
 `require` syntax fix to ensure compatibility with clojure.spec/Clojure 1.9

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ available in your resources.
 Add to your project.clj's dependencies:
 
 ```clojure
-[turbovote.resource-config "0.2.1"]
+[democracyworks/resource-config "0.2.2-SNAPSHOT"]
 ```
 
 1. Create a `config.edn` file in your classpath.
-2. Use turbovote.resource-config!
+2. Use resource-config!
 
 ```clojure
 ; config.edn
@@ -25,7 +25,7 @@ Add to your project.clj's dependencies:
 ```clojure
 ; core.clj
 (ns my-app.core
-  (:require [turbovote.resource-config :refer [config]]))
+  (:require [resource-config :refer [config]]))
 
 ;; this will throw an exception if the value is not in the config
 (defn running-locally? []
@@ -48,7 +48,7 @@ The following data readers are provided:
 
 ## License
 
-Copyright © 2015 TurboVote
+Copyright © 2015-2018 Democracy Works, Inc.
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ Add to your project.clj's dependencies:
   (config [:database :url] "postgres://default-db"))
 ```
 
+### Using it with the mount library
+
+```clojure
+(ns my-app.core
+  (:require [mount.core :refer [defstate] :as mount]
+            [resource-config.core :as rc]))
+  
+(defstate config
+  :start rc/config
+  :stop (rc/reload-config!))
+  
+(mount/start)
+
+(config [:database :url] "postgres://default-db")
+```
+
 ### Data readers
 
 The following data readers are provided:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ available in your resources.
 
 ## Usage
 
-Add to your project.clj's dependencies:
+Add to your project's dependencies:
 
-```clojure
-[democracyworks/resource-config "0.2.2-SNAPSHOT"]
-```
+[![Clojars Project](https://img.shields.io/clojars/v/democracyworks/resource-config.svg)](https://clojars.org/democracyworks/resource-config)
 
 1. Create a `config.edn` file in your classpath.
 2. Use resource-config!

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add to your project.clj's dependencies:
 ```clojure
 ; core.clj
 (ns my-app.core
-  (:require [resource-config :refer [config]]))
+  (:require [resource-config.core :refer [config]]))
 
 ;; this will throw an exception if the value is not in the config
 (defn running-locally? []

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject turbovote.resource-config "0.2.1"
+(defproject resource-config "0.2.2-SNAPSHOT"
   :description "Simple (too simple?) configuration handling"
-  :url "http://github.com/turbovote/resource-config"
+  :url "http://github.com/democracyworks/resource-config"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject resource-config "0.2.2-SNAPSHOT"
+(defproject resource-config "1.0.0-SNAPSHOT"
   :description "Simple (too simple?) configuration handling"
   :url "http://github.com/democracyworks/resource-config"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,8 @@
   :url "http://github.com/democracyworks/resource-config"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
+                 [org.clojure/core.memoize "0.5.6"]]
   :profiles {:test {:resource-paths ["test-resources"]}}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject resource-config "1.0.0-SNAPSHOT"
+(defproject democracyworks/resource-config "1.0.0-SNAPSHOT"
   :description "Simple (too simple?) configuration handling"
   :url "http://github.com/democracyworks/resource-config"
   :license {:name "Eclipse Public License"

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,2 +1,2 @@
-{resource-config/env turbovote.resource-config.data-readers/env
- resource-config/edn turbovote.resource-config.data-readers/edn}
+{resource-config/env resource-config.data-readers/env
+ resource-config/edn resource-config.data-readers/edn}

--- a/src/resource_config/core.clj
+++ b/src/resource_config/core.clj
@@ -1,5 +1,5 @@
-(ns turbovote.resource-config
-  (:require [turbovote.resource-config.data-readers]
+(ns resource-config.core
+  (:require [resource-config.data-readers]
             [clojure.edn :as edn]
             [clojure.java.io :as io]))
 

--- a/src/resource_config/data_readers.clj
+++ b/src/resource_config/data_readers.clj
@@ -1,4 +1,4 @@
-(ns turbovote.resource-config.data-readers
+(ns resource-config.data-readers
   (:require [clojure.edn :as edn]))
 
 (defn env [variable]

--- a/test-resources/other-config.edn
+++ b/test-resources/other-config.edn
@@ -1,0 +1,1 @@
+{:startup-message "Hello, upside down!"}

--- a/test/resource_config/core_test.clj
+++ b/test/resource_config/core_test.clj
@@ -1,6 +1,6 @@
-(ns turbovote.resource-config-test
+(ns resource-config.core-test
   (:require [clojure.test :refer :all]
-            [turbovote.resource-config :refer [config]]))
+            [resource-config.core :refer [config]]))
 
 (deftest config-test
   (is (= (config [:startup-message]) "Hello, world!"))
@@ -30,5 +30,5 @@
 (deftest missing-config-test
   (is (thrown-with-msg?
        java.io.FileNotFoundException #"Config file __missing__\.edn not found in resource paths"
-       (with-redefs [turbovote.resource-config/config-file-name "__missing__.edn"]
+       (with-redefs [resource-config.core/config-file-name "__missing__.edn"]
          (config :foo)))))

--- a/test/resource_config/core_test.clj
+++ b/test/resource_config/core_test.clj
@@ -1,6 +1,8 @@
 (ns resource-config.core-test
   (:require [clojure.test :refer :all]
-            [resource-config.core :refer [config]]))
+            [resource-config.core :refer [config reload-config!]])
+  (:import (java.io FileNotFoundException)
+           (clojure.lang ExceptionInfo)))
 
 (deftest config-test
   (is (= (config [:startup-message]) "Hello, world!"))
@@ -15,7 +17,7 @@
 
 (deftest config-missing-test
   (testing "non-existing paths throw an exception"
-    (is (thrown? clojure.lang.ExceptionInfo
+    (is (thrown? ExceptionInfo
                  (config [:some :random :path :that :does :not :exist]))))
   (testing "false and nil in the config does not trigger exception"
     (is (false? (config [:test :false])))
@@ -29,6 +31,12 @@
 
 (deftest missing-config-test
   (is (thrown-with-msg?
-       java.io.FileNotFoundException #"Config file __missing__\.edn not found in resource paths"
+       FileNotFoundException #"Config file __missing__\.edn not found in resource paths"
        (with-redefs [resource-config.core/config-file-name "__missing__.edn"]
          (config :foo)))))
+
+(deftest reloaded-config-test
+  (is (= (config [:startup-message]) "Hello, world!"))
+  (reload-config!)
+  (with-redefs [resource-config.core/config-file-name "other-config.edn"]
+    (is (= (config [:startup-message]) "Hello, upside down!"))))


### PR DESCRIPTION
Some long-overdue improvements and sync-ups with our current practice in here. This will allow using this with lifecycle management tools like component, integrant, and mount.